### PR TITLE
Use alternative method to set Content-Type

### DIFF
--- a/Tests/UnitTests.WebView.WinForms/FunctionalTests/Navigation/NavigateWithHttpMessageTests.cs
+++ b/Tests/UnitTests.WebView.WinForms/FunctionalTests/Navigation/NavigateWithHttpMessageTests.cs
@@ -74,4 +74,39 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTe
             _success.ShouldBeTrue();
         }
     }
+
+    [TestClass]
+    [TestCategory(TestConstants.Categories.Nav)]
+    public class HTTP_POST_CONTENT : HostFormWebViewContextSpecification
+    {
+        private bool _success;
+        private Uri _uri = new Uri(TestConstants.Uris.HttpBin, "/post");
+
+        protected override void Given()
+        {
+            base.Given();
+            WebView.NavigationCompleted += (o, e) =>
+            {
+                _success = e.IsSuccess;
+                Form.Close();
+            };
+        }
+
+        protected override void When()
+        {
+
+            NavigateAndWaitForFormClose(
+                _uri,
+                HttpMethod.Post,
+                "say=Hello&to=World",
+                new[] { new KeyValuePair<string, string>("Content-Type", "application/x-www-form-urlencoded"), });
+        }
+
+        [TestMethod]
+        [Timeout(TestConstants.Timeouts.Longest)]
+        public void NavigationShouldComplete()
+        {
+            _success.ShouldBeTrue();
+        }
+    }
 }

--- a/WebView.Shared/Interop/WinRT/WebViewControlHost.cs
+++ b/WebView.Shared/Interop/WinRT/WebViewControlHost.cs
@@ -13,6 +13,7 @@ using Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32;
 using Windows.Foundation.Metadata;
 using Windows.Web;
 using Windows.Web.Http;
+using Windows.Web.Http.Headers;
 using Windows.Web.UI;
 using Windows.Web.UI.Interop;
 using Rect = Windows.Foundation.Rect;
@@ -619,7 +620,18 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
             {
                 foreach (var header in headers)
                 {
-                    requestMessage.Headers.Add(header);
+                    // The Content-Type header can only be specified with requests that have content (e.g. POST, PUT, etc.)
+                    // Not setting in this manner results in an exception:
+                    //  "Misused header name. Make sure request headers are used with HttpRequestMessage, response headers with HttpResponseMessage, and content headers with HttpContent objects."
+                    if ("Content-Type".Equals(header.Key, StringComparison.OrdinalIgnoreCase) &&
+                        requestMessage.Content != null)
+                    {
+                        requestMessage.Content.Headers.ContentType = new HttpMediaTypeHeaderValue(header.Value);
+                    }
+                    else
+                    {
+                        requestMessage.Headers.Add(header);
+                    }
                 }
             }
 


### PR DESCRIPTION
Issue: windows-toolkit/WindowsCommunityToolkit#2673
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When submitting a header that should be on the Content (e.g. `Content-Type`) an invalid operation exception is thrown.

## What is the new behavior?
No exception is thrown and value is set

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
