### PR TITLE
WebView WPF Layout Issues

### DIFF
--- a/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebView.cs
+++ b/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebView.cs
@@ -1205,7 +1205,20 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
             width *= DpiScale.DpiScaleX;
             height *= DpiScale.DpiScaleY;
 
-            // HACK: looks like the vertical pos is counted twice, giving a gap
+            // The vertical and horizontal coordinates are relative to the window, not the containing control
+            // Given a Grid with three columns 200px wide each, e.g.
+            // <Grid>
+            //  <Grid.ColumnDefinitions>
+            //    <ColumnDefinition Width="200" />
+            //    <ColumnDefinition Width="200" />
+            //    <ColumnDefinition Width="200" />
+            //  </Grid.ColumnDefinitions>
+            // </Grid>
+            //
+            // A WebView in the second column would have an X value of 200, placing it in the third column of the grid
+            //
+            // HACK: Looks like the vertical and horizontal pos are counted twice, giving gaps
+            x = 0;
             y = 0;
 
 #if DEBUG_LAYOUT

--- a/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebView.cs
+++ b/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebView.cs
@@ -789,15 +789,6 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
 
                     Verify.IsNotNull(_webViewControl);
 
-                    if (!Dispatcher.CheckAccess())
-                    {
-                        Dispatcher.Invoke(() => UpdateSize(RenderSize));
-                    }
-                    else
-                    {
-                        UpdateSize(RenderSize);
-                    }
-
                     DestroyWindowCore(ChildWindow);
 
                     SubscribeEvents();
@@ -831,6 +822,16 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
 
                     _initializationState = InitializationState.IsInitialized;
                     _initializationComplete.Set();
+
+                    // Ensures the size is correctly updated after the initialization as UpdateSize gates on control initialization
+                    if (!Dispatcher.CheckAccess())
+                    {
+                        Dispatcher.Invoke(() => UpdateSize(RenderSize));
+                    }
+                    else
+                    {
+                        UpdateSize(RenderSize);
+                    }
                 },
                 DispatcherPriority.Send);
         }

--- a/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebView.cs
+++ b/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebView.cs
@@ -1198,7 +1198,7 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
 #if DEBUG_LAYOUT
             Debug.WriteLine($"{Name}::{nameof(UpdateBounds)}");
             Debug.Indent();
-            Debug.WriteLine($"oldBounds={{x={x:F0} y={y:F0} width={width:F0} height={height:F0}}}");
+            Debug.WriteLine($"oldBounds={{x={x:F0} y={y:F0} width={width:F0} height={height:F0} }}");
 #endif
 
             // Update bounds here to ensure correct draw position
@@ -1222,7 +1222,7 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
             y = 0;
 
 #if DEBUG_LAYOUT
-            Debug.WriteLine($"newBounds={{x={x:F0} y={y:F0} width={width:F0} height={height:F0}}}");
+            Debug.WriteLine($"newBounds={{x={x:F0} y={y:F0} width={width:F0} height={height:F0} }}");
 #endif
             if (WebViewControlInitialized)
             {


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
WebView in WPF layouts does not function as expected:
- When initializing a WebView programmatically, a grey box is displayed instead of the WebView until the Window is resized
- When initializing a WebView within a columned layout, such as a Grid, a grey box is displayed instead of the WebView. Window resizing does not render the control.
- Diagnostic messages relating to HWND position have a formatting error

## What is the new behavior?
- **Ensure WebView is initialized prior to WindowPOS call**. During initialization the size of the control may not be correctly set causing a grey rect to be displayed. This is due to a timing issue with the dispatcher wherein the control has been resized by the visual layout system but has not yet finished initialization, causing the bounds to not be set. The call to update the render size has been moved to after the control is initialized to resolve this issue. It causes a noticeable layout event wherein the grey box is displayed then swapped for the actual control.
- **Reset horizontal pos during WPF WebView bounds update**. The vertical and horizontal coordinates are relative to the Window, not the containing UIElement. Given a Window with a Grid of only three columns, each 200px wide, the WebView set to Grid position 0,1 X value of 200, placing it in the third column of the Grid instead of the expected second column. There was already a hack in place to zero out the Y position of the location. This has been extended to the X position as well.
- **Fix DEBUG_LAYOUT messages for WPF WebView**. When writing the updated RECT the value displayed incorrectly as `oldBounds={x=371 y=0 width=371 height=F655}}` rather than `oldBounds={x=371 y=0 width=371 height=655}`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Issues originally found in 5.0.1 of WebView NuGet package on 1809 by @joshholmes (we can link his issue to this PR when available). Fix verified on RS4 1803 17134.345, RS5 1809 17763.134, and Insiders 1809 18290.1000.