### PR TITLE
Adding the Max Version ID to the sample app Manifest to avoid exceptions

### DIFF
--- a/Microsoft.Toolkit.Sample.Forms.App/app.manifest
+++ b/Microsoft.Toolkit.Sample.Forms.App/app.manifest
@@ -40,6 +40,7 @@
       <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
 
       <!-- Windows 10 -->
+      <maxversiontested Id="10.0.18295.0"/>
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
 
     </application>

--- a/Microsoft.Toolkit.Sample.Wpf.App/app.manifest
+++ b/Microsoft.Toolkit.Sample.Wpf.App/app.manifest
@@ -40,7 +40,9 @@
       <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
 
       <!-- Windows 10 -->
+      <maxversiontested Id="10.0.18295.0"/>
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
     </application>
   </compatibility>
 


### PR DESCRIPTION
Adding the Max Version ID to the apps' Manifest to make the tests run in future builds of Windows

Issue: #
In the latest insider Windows 10 builds, the app throws an exception because the MaxVersion wasn't set up.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
- Sample app changes 
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you run the app in an insider builds, the test apps crash.

## What is the new behavior?
The app is no longer crashing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
