### PR TITLE
Gegao/updated host

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <IsWpfProject Condition="'$(IsDesignProject)' != 'true'">$(MSBuildProjectName.Contains('Wpf'))</IsWpfProject>
     <IsFormsProject Condition="'$(IsDesignProject)' != 'true'">$(MSBuildProjectName.Contains('Forms'))</IsFormsProject>
     <IsSampleProject>$(MSBuildProjectName.Contains('Sample'))</IsSampleProject>
-    <DefaultTargetPlatformVersion>17763</DefaultTargetPlatformVersion>
+    <DefaultTargetPlatformVersion>18282</DefaultTargetPlatformVersion>
     <DefaultTargetPlatformMinVersion>16299</DefaultTargetPlatformMinVersion>
     <PackageOutputPath>$(MSBuildThisFileDirectory)bin\nupkg</PackageOutputPath>
   </PropertyGroup>
@@ -43,9 +43,9 @@
           - /azure-pipelines.yml
 
         This also needs to be installed on your local machine. Can do this with PowerShell:
-          ./build/Install-WindowsSDKISO.ps1 17763
+          ./build/Install-WindowsSDKISO.ps1 18282
         -->
-        <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+        <TargetPlatformVersion>10.0.18282.0</TargetPlatformVersion>
         <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
 
         <!-- Compiler -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,9 +43,9 @@
           - /azure-pipelines.yml
 
         This also needs to be installed on your local machine. Can do this with PowerShell:
-          ./build/Install-WindowsSDKISO.ps1 18282
+          ./build/Install-WindowsSDKISO.ps1 18298
         -->
-        <TargetPlatformVersion>10.0.18282.0</TargetPlatformVersion>
+        <TargetPlatformVersion>10.0.18298.0</TargetPlatformVersion>
         <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
 
         <!-- Compiler -->

--- a/Microsoft.Toolkit.Forms.UI.XamlHost/Microsoft.Toolkit.Forms.UI.XamlHost.csproj
+++ b/Microsoft.Toolkit.Forms.UI.XamlHost/Microsoft.Toolkit.Forms.UI.XamlHost.csproj
@@ -11,9 +11,10 @@
     <PackageTags>XAML Islands Win32 Forms WindowsForms WinForms XamlHost</PackageTags>
 
     <!--
-    Need class WIndows.UI.Xaml.Hosting.DesktopWindowXamlSource, which was introduced in Insiders SDK 17692 on 19-Jun 2018
+    Needs the XamlRoot API, which is available in Insiders SDK 18298 on 19-Dec 2018
+    https://blogs.windows.com/buildingapps/2018/12/19/windows-10-sdk-preview-build-18298-available-now
     -->
-    <TargetPlatformMinVersion>10.0.17692.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.18298.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -5,12 +5,11 @@
 using System;
 using System.ComponentModel;
 using System.Drawing;
-using System.Security.Permissions;
 using System.Windows.Forms;
-using Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32;
 using Microsoft.Toolkit.Win32.UI.XamlHost;
 using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 
 namespace Microsoft.Toolkit.Forms.UI.XamlHost
 {
@@ -72,6 +71,15 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         private double _lastDpi = 96.0f;
 
         /// <summary>
+        ///     When a window containing Xaml content moves, Xaml closes all open popups. We need the same behavior for Xaml
+        ///     content in the DesktopWindowXamlSource. Since the DesktopWindowXamlSource itself is not notified when the
+        ///     Form moves, we attach handlers to the Form's SizeChanged and LocationChanged events and use the Xaml
+        ///     VisualTreeHelper API to close all open popups in an event handler. The Form is not reachable until after
+        ///     this control is created. This field tracks the Form so we can detach the event handlers during cleanup.
+        /// </summary>
+        private Form _form;
+
+        /// <summary>
         ///     Fired when XAML content has been updated
         /// </summary>
         [Browsable(true)]
@@ -130,6 +138,8 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
             // Add scaling panel as the root XAML element
             _xamlSource.Content = new DpiScalingPanel();
+
+            HandleCreated += WindowsXamlHostBase_HandleCreated;
         }
 
         protected WindowsXamlHostBase(string typeName)
@@ -139,6 +149,34 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             {
                 ChildInternal = UWPTypeFactory.CreateXamlContentByType(typeName);
                 ChildInternal.SetWrapper(this);
+            }
+        }
+
+        /// <summary>
+        /// Attaches event handlers to Form.SizeChanged and Form.LocationChanged to close all popups opened by the
+        /// Xaml content inside the DesktopWindowXamlSource.
+        /// </summary>
+        private void WindowsXamlHostBase_HandleCreated(object sender, EventArgs e)
+        {
+            if (_form == null)
+            {
+                _form = FindForm();
+                _form.SizeChanged += OnFormSizeOrLocationChanged;
+                _form.LocationChanged += OnFormSizeOrLocationChanged;
+            }
+        }
+
+        /// <summary>
+        /// Close all popups opened by the Xaml content inside the DesktopWindowXamlSource.
+        /// </summary>
+        private void OnFormSizeOrLocationChanged(object sender, EventArgs e)
+        {
+#pragma warning disable 8305    // Experimental API
+            ContentRoot contentRoot = ContentRoot.GetForElement(_childInternal);
+            var openPopups = VisualTreeHelper.GetOpenPopupsWithinContentRoot(contentRoot);
+            foreach (Windows.UI.Xaml.Controls.Primitives.Popup popup in openPopups)
+            {
+                popup.IsOpen = false;
             }
         }
 
@@ -246,6 +284,13 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             {
                 SizeChanged -= OnWindowXamlHostSizeChanged;
                 ChildInternal?.ClearWrapper();
+
+                if (_form != null)
+                {
+                    _form.SizeChanged -= OnFormSizeOrLocationChanged;
+                    _form.LocationChanged -= OnFormSizeOrLocationChanged;
+                    _form = null;
+                }
 
                 // Required by CA2213: _xamlSource?.Dispose() is insufficient.
                 if (_xamlSource != null)

--- a/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -172,8 +172,8 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         private void OnFormSizeOrLocationChanged(object sender, EventArgs e)
         {
 #pragma warning disable 8305    // Experimental API
-            ContentRoot contentRoot = ContentRoot.GetForElement(_childInternal);
-            var openPopups = VisualTreeHelper.GetOpenPopupsWithinContentRoot(contentRoot);
+            XamlRoot xamlRoot = _childInternal.XamlRoot;
+            var openPopups = VisualTreeHelper.GetOpenPopupsForXamlRoot(xamlRoot);
             foreach (Windows.UI.Xaml.Controls.Primitives.Popup popup in openPopups)
             {
                 popup.IsOpen = false;

--- a/Microsoft.Toolkit.Sample.Forms.App/Form1.cs
+++ b/Microsoft.Toolkit.Sample.Forms.App/Form1.cs
@@ -61,6 +61,16 @@ namespace Microsoft.Toolkit.Win32.Samples.WinForms.App
                 Content = "Another long UWP Button",
             });
 
+            var comboBox = new Windows.UI.Xaml.Controls.ComboBox()
+            {
+                HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Center,
+            };
+            comboBox.Items.Add("One");
+            comboBox.Items.Add("Two");
+            comboBox.Items.Add("Three");
+            comboBox.Items.Add("Four");
+            stackPanel.Children.Add(comboBox);
+
             windowsXamlHost.Child = stackPanel;
         }
     }

--- a/Microsoft.Toolkit.Sample.Forms.App/Form1.cs
+++ b/Microsoft.Toolkit.Sample.Forms.App/Form1.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Toolkit.Win32.Samples.WinForms.App
 {
     public partial class Form1 : Form
     {
+        private Windows.UI.Xaml.Controls.ContentDialog _contentDialog;
+
         public Form1()
         {
             InitializeComponent();
@@ -18,8 +20,8 @@ namespace Microsoft.Toolkit.Win32.Samples.WinForms.App
         private void Form1_Load(object sender, EventArgs e)
         {
             inkCanvas1.InkPresenter.InputDeviceTypes = CoreInputDeviceTypes.Pen | CoreInputDeviceTypes.Mouse | CoreInputDeviceTypes.Touch;
-            
-            var stackPanel = new Windows.UI.Xaml.Controls.StackPanel()
+
+            Windows.UI.Xaml.Controls.StackPanel stackPanel = new Windows.UI.Xaml.Controls.StackPanel()
             {
                 Background = new Windows.UI.Xaml.Media.SolidColorBrush(Windows.UI.Colors.Black),
             };
@@ -38,13 +40,15 @@ namespace Microsoft.Toolkit.Win32.Samples.WinForms.App
                 Fill = new Windows.UI.Xaml.Media.SolidColorBrush(Windows.UI.Colors.Red),
             });
 
-            stackPanel.Children.Add(new Windows.UI.Xaml.Controls.Button()
+            var button = new Windows.UI.Xaml.Controls.Button()
             {
                 Width = 160,
                 Height = 60,
                 HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Center,
-                Content = "This is a UWP Button",
-            });
+                Content = "ContentDialog UWP Button",
+            };
+            button.Tapped += Button_Tapped;
+            stackPanel.Children.Add(button);
 
             stackPanel.Children.Add(new Windows.UI.Xaml.Shapes.Rectangle()
             {
@@ -53,13 +57,18 @@ namespace Microsoft.Toolkit.Win32.Samples.WinForms.App
                 Fill = new Windows.UI.Xaml.Media.SolidColorBrush(Windows.UI.Colors.Green),
             });
 
-            stackPanel.Children.Add(new Windows.UI.Xaml.Controls.Button()
+            Windows.UI.Xaml.Controls.Flyout flyout = new Windows.UI.Xaml.Controls.Flyout();
+            flyout.Content = new Windows.UI.Xaml.Controls.TextBlock() { Text = "Flyout content", };
+
+            var button2 = new Windows.UI.Xaml.Controls.Button()
             {
                 Width = 300,
                 Height = 40,
                 HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Center,
-                Content = "Another long UWP Button",
-            });
+                Content = "Long UWP Button with Flyout",
+                Flyout = flyout,
+            };
+            stackPanel.Children.Add(button2);
 
             var comboBox = new Windows.UI.Xaml.Controls.ComboBox()
             {
@@ -71,7 +80,28 @@ namespace Microsoft.Toolkit.Win32.Samples.WinForms.App
             comboBox.Items.Add("Four");
             stackPanel.Children.Add(comboBox);
 
+            Windows.UI.Xaml.Controls.Grid grid = new Windows.UI.Xaml.Controls.Grid();
+            stackPanel.Children.Add(grid);
+
+            _contentDialog = new Windows.UI.Xaml.Controls.ContentDialog();
+            _contentDialog.Content = new Windows.UI.Xaml.Controls.TextBlock() { Text = "ContentDialog content", };
+            stackPanel.Children.Add(_contentDialog);
+
+            var popup = new Windows.UI.Xaml.Controls.Primitives.Popup()
+            {
+                Width = 50,
+                Height = 50,
+                ShouldConstrainToRootBounds = false,
+                Child = new Windows.UI.Xaml.Controls.TextBlock() { Text = "Popup child", },
+            };
+            grid.Children.Add(popup);
+
             windowsXamlHost.Child = stackPanel;
+            popup.IsOpen = true;
+        }
+        private async void Button_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
+        {
+            await _contentDialog.ShowAsync(Windows.UI.Xaml.Controls.ContentDialogPlacement.Popup);
         }
     }
 }

--- a/Microsoft.Toolkit.Sample.Wpf.App/MainWindow.xaml.cs
+++ b/Microsoft.Toolkit.Sample.Wpf.App/MainWindow.xaml.cs
@@ -117,16 +117,10 @@ namespace Microsoft.Toolkit.Sample.Wpf.App
             {
                 Width = 50,
                 Height = 50,
+                ShouldConstrainToRootBounds = false,
+                Child = new Windows.UI.Xaml.Controls.TextBlock() { Text = "Popup child", },
             };
             grid.Children.Add(popup);
-
-            var canvas = new Windows.UI.Xaml.Controls.Canvas()
-            {
-                Width = 50,
-                Height = 50,
-                Background = new Windows.UI.Xaml.Media.SolidColorBrush(Windows.UI.Colors.Green),
-            };
-            popup.Child = canvas;
 
             windowsXamlHost.Child = stackPanel;
             popup.IsOpen = true;

--- a/Microsoft.Toolkit.Wpf.UI.XamlHost/Microsoft.Toolkit.Wpf.UI.XamlHost.csproj
+++ b/Microsoft.Toolkit.Wpf.UI.XamlHost/Microsoft.Toolkit.Wpf.UI.XamlHost.csproj
@@ -12,9 +12,10 @@
     <PackageId>Microsoft.Toolkit.Wpf.UI.XamlHost</PackageId>
 
     <!--
-    Need class WIndows.UI.Xaml.Hosting.DesktopWindowXamlSource, which was introduced in Insiders SDK 17692 on 19-Jun 2018
+    Needs the XamlRoot API, which is available in Insiders SDK 18298 on 19-Dec 2018
+    https://blogs.windows.com/buildingapps/2018/12/19/windows-10-sdk-preview-build-18298-available-now
     -->
-    <TargetPlatformMinVersion>10.0.17692.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.18298.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Interop;
 using Microsoft.Toolkit.Win32.UI.XamlHost;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 
 namespace Microsoft.Toolkit.Wpf.UI.XamlHost
 {
@@ -20,7 +21,7 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
         /// probe at runtime for custom UWP XAML type information.  This must be created before
         /// creating any DesktopWindowXamlSource instances if custom UWP XAML types are required.
         /// </summary>
-        private readonly Windows.UI.Xaml.Application _application;
+        private readonly Application _application;
 
         /// <summary>
         /// UWP XAML DesktopWindowXamlSource instance that hosts XAML content in a win32 application
@@ -45,6 +46,15 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
         public event EventHandler ChildChanged;
 
         /// <summary>
+        ///     When a window containing Xaml content moves, Xaml closes all open popups. We need the same behavior for Xaml
+        ///     content in the DesktopWindowXamlSource. Since the DesktopWindowXamlSource itself is not notified when the WPF
+        ///     Window moves, we attach handlers to the WPF Window's SizeChanged and LocationChanged events and use the Xaml
+        ///     VisualTreeHelper API to close all open popups in an event handler. The WPF Window is not reachable until after
+        ///     this control is created. This field tracks the WPF Window so we can detach the event handlers during cleanup.
+        /// </summary>
+        private System.Windows.Window _window;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="WindowsXamlHostBase"/> class.
         /// </summary>
         /// <remarks>
@@ -56,7 +66,7 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
             // Windows.UI.Xaml.Application object is required for loading custom control metadata.  If a custom
             // Application object is not provided by the application, the host control will create one (XamlApplication).
             // Instantiation of the application object must occur before creating the DesktopWindowXamlSource instance.
-            // If no Application object is created before DesktopWindowXamlSource is created, DestkopWindowXamlSource
+            // If no Application object is created before DesktopWindowXamlSource is created, DesktopWindowXamlSource
             // will create a generic Application object unable to load custom UWP XAML metadata.
             Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication.GetOrCreateXamlApplicationInstance(ref _application);
 
@@ -73,6 +83,8 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
 
             // Hook DesktopWindowXamlSource OnTakeFocus event for Focus processing
             _xamlSource.TakeFocusRequested += OnTakeFocusRequested;
+
+            Loaded += WindowsXamlHostBase_Loaded;
         }
 
         /// <summary>
@@ -88,6 +100,34 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
         {
             ChildInternal = UWPTypeFactory.CreateXamlContentByType(typeName);
             ChildInternal.SetWrapper(this);
+        }
+
+        /// <summary>
+        /// Attaches event handlers to Window.SizeChanged and Window.LocationChanged to close all popups opened by the
+        /// Xaml content inside the DesktopWindowXamlSource.
+        /// </summary>
+        private void WindowsXamlHostBase_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (_window == null)
+            {
+                _window = System.Windows.Window.GetWindow(this);
+                _window.SizeChanged += OnWindowSizeOrLocationChanged;
+                _window.LocationChanged += OnWindowSizeOrLocationChanged;
+            }
+        }
+
+        /// <summary>
+        /// Close all popups opened by the Xaml content inside the DesktopWindowXamlSource.
+        /// </summary>
+        private void OnWindowSizeOrLocationChanged(object sender, EventArgs e)
+        {
+#pragma warning disable 8305    // Experimental API
+            ContentRoot contentRoot = ContentRoot.GetForElement(_childInternal);
+            var openPopups = VisualTreeHelper.GetOpenPopupsWithinContentRoot(contentRoot);
+            foreach (Windows.UI.Xaml.Controls.Primitives.Popup popup in openPopups)
+            {
+                popup.IsOpen = false;
+            }
         }
 
         /// <summary>
@@ -244,6 +284,13 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
             if (disposing)
             {
                 ChildInternal = null;
+
+                if (_window != null)
+                {
+                    _window.SizeChanged -= OnWindowSizeOrLocationChanged;
+                    _window.LocationChanged -= OnWindowSizeOrLocationChanged;
+                    _window = null;
+                }
 
                 // Required by CA2213: _xamlSource?.Dispose() is insufficient.
                 if (_xamlSource != null)

--- a/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
@@ -122,8 +122,8 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
         private void OnWindowSizeOrLocationChanged(object sender, EventArgs e)
         {
 #pragma warning disable 8305    // Experimental API
-            ContentRoot contentRoot = ContentRoot.GetForElement(_childInternal);
-            var openPopups = VisualTreeHelper.GetOpenPopupsWithinContentRoot(contentRoot);
+            XamlRoot xamlRoot = _childInternal.XamlRoot;
+            var openPopups = VisualTreeHelper.GetOpenPopupsForXamlRoot(xamlRoot);
             foreach (Windows.UI.Xaml.Controls.Primitives.Popup popup in openPopups)
             {
                 popup.IsOpen = false;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ steps:
 - script: nbgv cloud
   displayName: Set Version
       
-- powershell: .\build\Install-WindowsSdkISO.ps1 17763
+- powershell: .\build\Install-WindowsSdkISO.ps1 18298
   displayName: Insider SDK
 
 - powershell: .\build\build.ps1 -target=Package


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
Feature


## What is the current behavior?
Open popups stay open if the DesktopWindowXamlSource host window moves or resizes. They don't move with the window so they get out-of-sync.


## What is the new behavior?
WindowsXamlHost now listens for the Form or the WPF Window's movement and size changing events, and explicitly closes the popups inside its DesktopWindowXamlSource.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
Updating the SDK version to 18298, which contains the XamlRoot APIs needed to get a list of open popups corresponding to a DesktopWindowXamlSource.


## Other information
