### PR TITLE
change logic of closing open popups on move/size

### DIFF
--- a/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -161,22 +161,36 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             if (_form == null)
             {
                 _form = FindForm();
-                _form.SizeChanged += OnFormSizeOrLocationChanged;
-                _form.LocationChanged += OnFormSizeOrLocationChanged;
+                _form.LocationChanged += OnFormLocationChanged;
             }
         }
 
         /// <summary>
         /// Close all popups opened by the Xaml content inside the DesktopWindowXamlSource.
         /// </summary>
-        private void OnFormSizeOrLocationChanged(object sender, EventArgs e)
+        private void OnFormLocationChanged(object sender, EventArgs e)
         {
 #pragma warning disable 8305    // Experimental API
             XamlRoot xamlRoot = _childInternal.XamlRoot;
             var openPopups = VisualTreeHelper.GetOpenPopupsForXamlRoot(xamlRoot);
             foreach (Windows.UI.Xaml.Controls.Primitives.Popup popup in openPopups)
             {
-                popup.IsOpen = false;
+                // Toggle the CompositeMode property, which will force all windowed Popups
+                // to reposition themselves relative to the new position of the host window.
+                var compositeMode = popup.CompositeMode;
+
+                // Set CompositeMode to some value it currently isn't set to.
+                if (compositeMode == ElementCompositeMode.SourceOver)
+                {
+                    popup.CompositeMode = ElementCompositeMode.MinBlend;
+                }
+                else
+                {
+                    popup.CompositeMode = ElementCompositeMode.SourceOver;
+                }
+
+                // Restore CompositeMode to whatever it was originally set to.
+                popup.CompositeMode = compositeMode;
             }
         }
 
@@ -287,8 +301,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
                 if (_form != null)
                 {
-                    _form.SizeChanged -= OnFormSizeOrLocationChanged;
-                    _form.LocationChanged -= OnFormSizeOrLocationChanged;
+                    _form.LocationChanged -= OnFormLocationChanged;
                     _form = null;
                 }
 

--- a/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
@@ -111,22 +111,36 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
             if (_window == null)
             {
                 _window = System.Windows.Window.GetWindow(this);
-                _window.SizeChanged += OnWindowSizeOrLocationChanged;
-                _window.LocationChanged += OnWindowSizeOrLocationChanged;
+                _window.LocationChanged += OnWindowLocationChanged;
             }
         }
 
         /// <summary>
         /// Close all popups opened by the Xaml content inside the DesktopWindowXamlSource.
         /// </summary>
-        private void OnWindowSizeOrLocationChanged(object sender, EventArgs e)
+        private void OnWindowLocationChanged(object sender, EventArgs e)
         {
 #pragma warning disable 8305    // Experimental API
             XamlRoot xamlRoot = _childInternal.XamlRoot;
             var openPopups = VisualTreeHelper.GetOpenPopupsForXamlRoot(xamlRoot);
             foreach (Windows.UI.Xaml.Controls.Primitives.Popup popup in openPopups)
             {
-                popup.IsOpen = false;
+                // Toggle the CompositeMode property, which will force all windowed Popups
+                // to reposition themselves relative to the new position of the host window.
+                var compositeMode = popup.CompositeMode;
+
+                // Set CompositeMode to some value it currently isn't set to.
+                if (compositeMode == ElementCompositeMode.SourceOver)
+                {
+                    popup.CompositeMode = ElementCompositeMode.MinBlend;
+                }
+                else
+                {
+                    popup.CompositeMode = ElementCompositeMode.SourceOver;
+                }
+
+                // Restore CompositeMode to whatever it was originally set to.
+                popup.CompositeMode = compositeMode;
             }
         }
 
@@ -287,8 +301,7 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
 
                 if (_window != null)
                 {
-                    _window.SizeChanged -= OnWindowSizeOrLocationChanged;
-                    _window.LocationChanged -= OnWindowSizeOrLocationChanged;
+                    _window.LocationChanged -= OnWindowLocationChanged;
                     _window = null;
                 }
 


### PR DESCRIPTION


Issue: #25 Xaml Island popups should not be closed when WPF/WinForms window is moved/sized

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

< - Bugfix >
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<In WPF/WinForms hosting Xaml Islands scenarios, all open popups are closed whenever the host window is moved or resized. This logic is problematic. In some cases popups that should not be closed are getting closed (eg ContentDialog)>


## What is the new behavior?
When host window is moved, all open popups will be re-positioned to follow the new position of the host window.  No action is taken when the host window is resized anymore.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
