### PR TITLE
Support 17763 and only use XamlRoot when it is available

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <IsFormsProject Condition="'$(IsDesignProject)' != 'true'">$(MSBuildProjectName.Contains('Forms'))</IsFormsProject>
     <IsSampleProject>$(MSBuildProjectName.Contains('Sample'))</IsSampleProject>
     <DefaultTargetPlatformVersion>18298</DefaultTargetPlatformVersion>
-    <DefaultTargetPlatformMinVersion>18226</DefaultTargetPlatformMinVersion>
+    <DefaultTargetPlatformMinVersion>17763</DefaultTargetPlatformMinVersion>
     <PackageOutputPath>$(MSBuildThisFileDirectory)bin\nupkg</PackageOutputPath>
   </PropertyGroup>
 
@@ -47,7 +47,7 @@
         -->
         <TargetPlatformVersion>10.0.18298.0</TargetPlatformVersion>
 		<!-- XAML Islands require SDK 18226 -->
-        <TargetPlatformMinVersion>10.0.18226.0</TargetPlatformMinVersion>
+        <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 
         <!-- Compiler -->
         <FileAlignment>512</FileAlignment>

--- a/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
@@ -6,6 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Windows.Interop;
 using Microsoft.Toolkit.Win32.UI.XamlHost;
+using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 using windows = Windows;
@@ -104,12 +105,13 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
         }
 
         /// <summary>
-        /// Attaches event handlers to Window.SizeChanged and Window.LocationChanged to close all popups opened by the
-        /// Xaml content inside the DesktopWindowXamlSource.
+        /// Attaches an event handler to Window.LocationChanged to close all popups opened by the
+        /// Xaml content inside the DesktopWindowXamlSource (Only if <code>Windows.UI.Xaml.XamlRoot</code> is present,
+        /// because this type is needed in the event handler).
         /// </summary>
         private void WindowsXamlHostBase_Loaded(object sender, System.Windows.RoutedEventArgs e)
         {
-            if (_window == null)
+            if (_window == null && ApiInformation.IsTypePresent("Windows.UI.Xaml.XamlRoot"))
             {
                 _window = System.Windows.Window.GetWindow(this);
                 _window.LocationChanged += OnWindowLocationChanged;


### PR DESCRIPTION
Set TargetPlatformMinVersion to 17763 and guard use of XamlRoot with ApiInformation

Issue: #73

## PR Type
- Bugfix

## What is the current behavior?
WindowsXamlHostBase (WPF) crashes on 17763 when host window is moved

## What is the new behavior?
No crash. Popups are not closed automatically

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
