### PR TITLE
Adding event WindowsXamlHostBase.ApplicationCreated

### DIFF
--- a/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -83,6 +83,11 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         private Form _form;
 
         /// <summary>
+        /// Fired when a new <see cref="windows.UI.Xaml.Application"/> instance was created.
+        /// </summary>
+        public static event EventHandler ApplicationCreated;
+
+        /// <summary>
         ///     Fired when XAML content has been updated
         /// </summary>
         [Browsable(true)]
@@ -120,7 +125,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             // Instantiation of the application object must occur before creating the DesktopWindowXamlSource instance.
             // If no Application object is created before DesktopWindowXamlSource is created, DestkopWindowXamlSource
             // will create a generic Application object unable to load custom UWP XAML metadata.
-            Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication.GetOrCreateXamlApplicationInstance(ref _application);
+            bool applicationCreated = Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication.GetOrCreateXamlApplicationInstance(ref _application);
 
             // Create an instance of the WindowsXamlManager. This initializes and holds a
             // reference on the UWP XAML DXamlCore and must be explicitly created before
@@ -129,6 +134,11 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             // will create an instance of WindowsXamlManager internally.  (Creation is explicit
             // here to illustrate how to initialize UWP XAML before initializing the DesktopWindowXamlSource.)
             _windowsXamlManager = windows.UI.Xaml.Hosting.WindowsXamlManager.InitializeForCurrentThread();
+
+            if (applicationCreated)
+            {
+                ApplicationCreated?.Invoke(_application, EventArgs.Empty);
+            }
 
             // Create DesktopWindowXamlSource, host for UWP XAML content
             _xamlSource = new windows.UI.Xaml.Hosting.DesktopWindowXamlSource();

--- a/Microsoft.Toolkit.Sample.Wpf.App/App.xaml.cs
+++ b/Microsoft.Toolkit.Sample.Wpf.App/App.xaml.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Toolkit.Wpf.UI.XamlHost;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -19,5 +20,24 @@ namespace Microsoft.Toolkit.Sample.Wpf.App
     public partial class App : Application
 #pragma warning restore CA1724 // Type names should not match namespaces
     {
+        public App()
+        {
+            WindowsXamlHostBase.ApplicationCreated += (sender, args) =>
+            {
+                if (sender is global::Windows.UI.Xaml.Application xamlApplication)
+                {
+                    // Setting dark theme for the XAML island even when windows is set to light theme.
+                    xamlApplication.RequestedTheme = global::Windows.UI.Xaml.ApplicationTheme.Dark;
+
+                    // You can include .xbf files (XAML Binary Format) from an UWP app as described in 
+                    // https://blogs.windows.com/buildingapps/2018/11/08/xaml-islands-a-deep-dive-part-2/
+                    // The .xbf can define any XAML like pages and styles. Here you can create the 
+                    // ResourceDictionary that will be used by the XAML in the island.
+
+                    // var stylesUri = new Uri("ms-appx:///App/Styles/AppStyles.xaml");
+                    // xamlApplication.Resources = new global::Windows.UI.Xaml.ResourceDictionary { Source = stylesUri };
+                }
+            };
+        }
     }
 }

--- a/Microsoft.Toolkit.Win32.UI.XamlHost/XamlApplication.cs
+++ b/Microsoft.Toolkit.Win32.UI.XamlHost/XamlApplication.cs
@@ -102,7 +102,8 @@ namespace Microsoft.Toolkit.Win32.UI.XamlHost
         /// If the current XAML Application instance has not been created for the process (is null),
         /// a new <see cref="Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication" /> instance is created and returned.
         /// </summary>
-        internal static void GetOrCreateXamlApplicationInstance(ref windows.UI.Xaml.Application application)
+        /// <returns>true, if a new instance was created; otherwise, false.</returns>
+        internal static bool GetOrCreateXamlApplicationInstance(ref windows.UI.Xaml.Application application)
         {
             // Instantiation of the application object must occur before creating the DesktopWindowXamlSource instance.
             // DesktopWindowXamlSource will create a generic Application object unable to load custom UWP XAML metadata.
@@ -118,8 +119,11 @@ namespace Microsoft.Toolkit.Win32.UI.XamlHost
                 {
                     // Create a custom UWP XAML Application object that implements reflection-based XAML metadata probing.
                     application = new XamlApplication();
+                    return true;
                 }
             }
+
+            return false;
         }
     }
 }

--- a/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Wpf.UI.XamlHost/WindowsXamlHostBase.cs
@@ -42,6 +42,11 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
         private UIElement _childInternal;
 
         /// <summary>
+        /// Fired when a new <see cref="windows.UI.Xaml.Application"/> instance was created.
+        /// </summary>
+        public static event EventHandler ApplicationCreated;
+
+        /// <summary>
         ///     Fired when WindowsXamlHost root UWP XAML content has been updated
         /// </summary>
         public event EventHandler ChildChanged;
@@ -69,7 +74,7 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
             // Instantiation of the application object must occur before creating the DesktopWindowXamlSource instance.
             // If no Application object is created before DesktopWindowXamlSource is created, DesktopWindowXamlSource
             // will create a generic Application object unable to load custom UWP XAML metadata.
-            Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication.GetOrCreateXamlApplicationInstance(ref _application);
+            bool applicationCreated = Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication.GetOrCreateXamlApplicationInstance(ref _application);
 
             // Create an instance of the WindowsXamlManager. This initializes and holds a
             // reference on the UWP XAML DXamlCore and must be explicitly created before
@@ -78,6 +83,11 @@ namespace Microsoft.Toolkit.Wpf.UI.XamlHost
             // will create an instance of WindowsXamlManager internally.  (Creation is explicit
             // here to illustrate how to initialize UWP XAML before initializing the DesktopWindowXamlSource.)
             _windowsXamlManager = windows.UI.Xaml.Hosting.WindowsXamlManager.InitializeForCurrentThread();
+
+            if (applicationCreated)
+            {
+                ApplicationCreated?.Invoke(_application, EventArgs.Empty);
+            }
 
             // Create DesktopWindowXamlSource, host for UWP XAML content
             _xamlSource = new windows.UI.Xaml.Hosting.DesktopWindowXamlSource();


### PR DESCRIPTION
Issue: #79

## PR Type
What kind of change does this PR introduce?

- Feature

## What is the current behavior?
There is no way to initialize the created XAML island application 


## What is the new behavior?
An event is fired

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
