### PR TITLE
Event handlers for WebResourceRequested event

### DIFF
--- a/Microsoft.Toolkit.Forms.UI.Controls.WebView/WebView.Events.cs
+++ b/Microsoft.Toolkit.Forms.UI.Controls.WebView/WebView.Events.cs
@@ -16,6 +16,7 @@ using WebViewControlPermissionRequestedEventArgs = Microsoft.Toolkit.Win32.UI.Co
 using WebViewControlScriptNotifyEventArgs = Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.WebViewControlScriptNotifyEventArgs;
 using WebViewControlUnsupportedUriSchemeIdentifiedEventArgs = Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.WebViewControlUnsupportedUriSchemeIdentifiedEventArgs;
 using WebViewControlUnviewableContentIdentifiedEventArgs = Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.WebViewControlUnviewableContentIdentifiedEventArgs;
+using WebViewControlWebResourceRequestedEventArgs = Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.WebViewControlWebResourceRequestedEventArgs;
 
 namespace Microsoft.Toolkit.Forms.UI.Controls
 {
@@ -167,6 +168,13 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         [StringResourceCategory(Constants.CategoryAction)]
         [StringResourceDescription(Constants.DescriptionWebViewUnviewableContentIdentified)]
         public event EventHandler<WebViewControlUnviewableContentIdentifiedEventArgs> UnviewableContentIdentified = (sender, args) => { };
+
+        /// <summary>
+        /// Occurs when <see cref="WebView"/> requests a web resource.
+        /// </summary>
+        [StringResourceCategory(Constants.CategoryAction)]
+        [StringResourceDescription(Constants.DescriptionWebViewWebResourceRequested)]
+        public event EventHandler<WebViewControlWebResourceRequestedEventArgs> WebResourceRequested = (sender, args) => { };
 
         private void OnAcceleratorKeyPressed(object sender, WebViewControlAcceleratorKeyPressedEventArgs args)
         {
@@ -344,6 +352,11 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
             {
                 handler(this, args);
             }
+        }
+
+        private void OnWebResourceRequested(object sender, WebViewControlWebResourceRequestedEventArgs args)
+        {
+            WebResourceRequested?.Invoke(this, args);
         }
     }
 }

--- a/Microsoft.Toolkit.Forms.UI.Controls.WebView/WebView.Init.cs
+++ b/Microsoft.Toolkit.Forms.UI.Controls.WebView/WebView.Init.cs
@@ -188,6 +188,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
             _webViewControl.UnsafeContentWarningDisplaying += OnUnsafeContentWarningDisplaying;
             _webViewControl.UnsupportedUriSchemeIdentified += OnUnsupportedUriSchemeIdentified;
             _webViewControl.UnviewableContentIdentified += OnUnviewableContentIdentified;
+            _webViewControl.WebResourceRequested += OnWebResourceRequested;
         }
 
         private void UnsubscribeEvents()
@@ -217,6 +218,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
             _webViewControl.UnsafeContentWarningDisplaying -= OnUnsafeContentWarningDisplaying;
             _webViewControl.UnsupportedUriSchemeIdentified -= OnUnsupportedUriSchemeIdentified;
             _webViewControl.UnviewableContentIdentified -= OnUnviewableContentIdentified;
+            _webViewControl.WebResourceRequested -= OnWebResourceRequested;
         }
     }
 }

--- a/Microsoft.Toolkit.Sample.Forms.WebView/Form1.Designer.cs
+++ b/Microsoft.Toolkit.Sample.Forms.WebView/Form1.Designer.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Toolkit.Sample.Forms.WebView
             this.webView1.NavigationStarting += new System.EventHandler<Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.WebViewControlNavigationStartingEventArgs>(this.webView1_NavigationStarting);
             this.webView1.PermissionRequested += new System.EventHandler<Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.WebViewControlPermissionRequestedEventArgs>(this.webView1_PermissionRequested);
             this.webView1.ScriptNotify += new System.EventHandler<Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.WebViewControlScriptNotifyEventArgs>(this.webView1_ScriptNotify);
+            this.webView1.WebResourceRequested += new System.EventHandler<Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.WebViewControlWebResourceRequestedEventArgs>(this.webView1_WebResourceRequested);
             // 
             // button2
             // 
@@ -150,7 +151,6 @@ namespace Microsoft.Toolkit.Sample.Forms.WebView
             this.ResumeLayout(false);
 
         }
-
 
         #endregion
 

--- a/Microsoft.Toolkit.Sample.Forms.WebView/Form1.cs
+++ b/Microsoft.Toolkit.Sample.Forms.WebView/Form1.cs
@@ -147,5 +147,10 @@ namespace Microsoft.Toolkit.Sample.Forms.WebView
         {
             MessageBox.Show(e.Value, e.Uri?.ToString() ?? string.Empty);
         }
+
+        private void webView1_WebResourceRequested(object sender, Win32.UI.Controls.Interop.WinRT.WebViewControlWebResourceRequestedEventArgs e)
+        {
+            
+        }
     }
 }

--- a/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebView.cs
+++ b/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebView.cs
@@ -311,6 +311,11 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unviewable", Justification = "Unviewable is in WinRT type")]
         public event EventHandler<WebViewControlUnviewableContentIdentifiedEventArgs> UnviewableContentIdentified = (sender, args) => { };
 
+        /// <inheritdoc />
+        [StringResourceCategory(Constants.CategoryAction)]
+        [StringResourceDescription(Constants.DescriptionWebViewWebResourceRequested)]
+        public event EventHandler<WebViewControlWebResourceRequestedEventArgs> WebResourceRequested = (sender, args) => { };
+
         /// <summary>
         /// Gets a value indicating whether <see cref="WebView"/> is supported in this environment.
         /// </summary>
@@ -1133,6 +1138,11 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
             }
         }
 
+        private void OnWebResourceRequested(object sender, WebViewControlWebResourceRequestedEventArgs args)
+        {
+            WebResourceRequested?.Invoke(this, args);
+        }
+
         private void SubscribeEvents()
         {
             Verify.IsNotNull(_webViewControl);
@@ -1161,6 +1171,7 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
             _webViewControl.UnsafeContentWarningDisplaying += OnUnsafeContentWarningDisplaying;
             _webViewControl.UnsupportedUriSchemeIdentified += OnUnsupportedUriSchemeIdentified;
             _webViewControl.UnviewableContentIdentified += OnUnviewableContentIdentified;
+            _webViewControl.WebResourceRequested += OnWebResourceRequested;
         }
 
         private void UnsubscribeEvents()
@@ -1191,6 +1202,7 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
             _webViewControl.UnsafeContentWarningDisplaying -= OnUnsafeContentWarningDisplaying;
             _webViewControl.UnsupportedUriSchemeIdentified -= OnUnsupportedUriSchemeIdentified;
             _webViewControl.UnviewableContentIdentified -= OnUnviewableContentIdentified;
+            _webViewControl.WebResourceRequested -= OnWebResourceRequested;
         }
 
         private void UpdateBounds(double x, double y, double width, double height)

--- a/WebView.Shared/IWebView.cs
+++ b/WebView.Shared/IWebView.cs
@@ -136,6 +136,11 @@ namespace Microsoft.Toolkit.Win32.UI.Controls
         event EventHandler<WebViewControlUnviewableContentIdentifiedEventArgs> UnviewableContentIdentified;
 
         /// <summary>
+        /// Allows the interception of an HTTP request. This event is triggered every time an HTTP request is made.
+        /// </summary>
+        event EventHandler<WebViewControlWebResourceRequestedEventArgs> WebResourceRequested;
+
+        /// <summary>
         /// Gets a value indicating whether there is at least one page in the backward navigation history.
         /// </summary>
         /// <value><c>true</c> if the <see cref="IWebView" /> can navigate backward; otherwise, <c>false</c>.</value>

--- a/WebView.Shared/Interop/WinRT/WebViewControlHost.cs
+++ b/WebView.Shared/Interop/WinRT/WebViewControlHost.cs
@@ -118,6 +118,8 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unviewable", Justification ="This is the name from WinRT")]
         internal event EventHandler<WebViewControlUnviewableContentIdentifiedEventArgs> UnviewableContentIdentified = (sender, args) => { };
 
+        internal event EventHandler<WebViewControlWebResourceRequestedEventArgs> WebResourceRequested = (sender, args) => { };
+
         internal static bool IsSupported => OSVersionHelper.IsWindows10April2018OrGreater
                                             && OSVersionHelper.IsWorkstation
                                             && OSVersionHelper.EdgeExists;
@@ -1050,6 +1052,13 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
 
         private void OnUnviewableContentIdentified(IWebViewControl sender, windows.Web.UI.WebViewControlUnviewableContentIdentifiedEventArgs args) => OnUnviewableContentIdentified(args);
 
+        private void OnWebResourceRequested(WebViewControlWebResourceRequestedEventArgs args)
+        {
+            WebResourceRequested?.Invoke(this, args);
+        }
+
+        private void OnWebResourceRequested(IWebViewControl sender, windows.Web.UI.WebViewControlWebResourceRequestedEventArgs args) => OnWebResourceRequested(args);
+
         [SecurityCritical]
         private void SubscribeEvents()
         {
@@ -1076,6 +1085,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
             _webViewControl.UnsafeContentWarningDisplaying += OnUnsafeContentWarningDisplaying;
             _webViewControl.UnsupportedUriSchemeIdentified += OnUnsupportedUriSchemeIdentified;
             _webViewControl.UnviewableContentIdentified += OnUnviewableContentIdentified;
+            _webViewControl.WebResourceRequested += OnWebResourceRequested;
 
             ApiInformationExtensions.ExecuteIfEventPresent(
                 WinRtType,
@@ -1124,6 +1134,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
             _webViewControl.UnsafeContentWarningDisplaying -= OnUnsafeContentWarningDisplaying;
             _webViewControl.UnsupportedUriSchemeIdentified -= OnUnsupportedUriSchemeIdentified;
             _webViewControl.UnviewableContentIdentified -= OnUnviewableContentIdentified;
+            _webViewControl.WebResourceRequested -= OnWebResourceRequested;
 
             ApiInformationExtensions.ExecuteIfEventPresent(
                 WinRtType,

--- a/WebView.Shared/Interop/WinRT/WebViewControlWebResourceRequestedEventArgs.cs
+++ b/WebView.Shared/Interop/WinRT/WebViewControlWebResourceRequestedEventArgs.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security;
+using Windows.Web.Http;
+using windows = Windows;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
+{
+    /// <summary>
+    /// CProvides data for the <see cref="IWebView.WebResourceRequested" /> event. This class cannot be inherited.
+    /// </summary>
+    /// <remarks>Copy from <see cref="windows.Web.UI.WebViewControlWebResourceRequestedEventArgs"/> to avoid requirement to link Windows.winmd</remarks>
+    /// <seealso cref="System.EventArgs" />
+    /// <seealso cref="windows.Web.UI.WebViewControlWebResourceRequestedEventArgs"/>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "WebResourceRequested", Justification = "Same as WinRT type")]
+    public sealed class WebViewControlWebResourceRequestedEventArgs : EventArgs
+    {
+        [SecurityCritical]
+        private readonly windows.Web.UI.WebViewControlWebResourceRequestedEventArgs _args;
+
+        internal WebViewControlWebResourceRequestedEventArgs(windows.Web.UI.WebViewControlWebResourceRequestedEventArgs args)
+        {
+            _args = args ?? throw new ArgumentNullException(nameof(args));
+        }
+
+        /// <summary>
+        /// Gets gets or sets the HTTP response that will be sent to the Windows.Web.UI.IWebViewControl
+        /// </summary>
+        /// <value>The response.</value>
+        public HttpResponseMessage Response => _args.Response;
+
+        /// <summary>
+        /// Gets a Deferral.
+        /// </summary>
+        /// <returns><seealso cref="windows.Foundation.Deferral"/></returns>
+        public windows.Foundation.Deferral GetDeferral() => _args.GetDeferral();
+
+        /// <summary>
+        /// Gets the intercepted HTTP request.
+        /// </summary>
+        /// <value>The request.</value>
+        public HttpRequestMessage Request => _args.Request;
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="windows.Web.UI.WebViewControlWebResourceRequestedEventArgs"/> to <see cref="WebViewControlWebResourceRequestedEventArgs"/>.
+        /// </summary>
+        /// <param name="args">The <see cref="windows.Web.UI.WebViewControlWebResourceRequestedEventArgs"/> instance containing the event data.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator WebViewControlWebResourceRequestedEventArgs(windows.Web.UI.WebViewControlWebResourceRequestedEventArgs args) => ToWebViewControlWebResourceRequestedEventArgs(args);
+
+        /// <summary>
+        /// Creates a <see cref="WebViewControlWebResourceRequestedEventArgs"/> from <see cref="windows.Web.UI.WebViewControlWebResourceRequestedEventArgs"/>.
+        /// </summary>
+        /// <param name="args">The <see cref="windows.Web.UI.WebViewControlWebResourceRequestedEventArgs"/> instance containing the event data.</param>
+        /// <returns><see cref="WebViewControlWebResourceRequestedEventArgs"/></returns>
+        public static WebViewControlWebResourceRequestedEventArgs
+            ToWebViewControlWebResourceRequestedEventArgs(
+                windows.Web.UI.WebViewControlWebResourceRequestedEventArgs args) =>
+            new WebViewControlWebResourceRequestedEventArgs(args);
+    }
+}

--- a/WebView.Shared/Interop/WinRT/WebViewControlWebResourceRequestedEventArgs.cs
+++ b/WebView.Shared/Interop/WinRT/WebViewControlWebResourceRequestedEventArgs.cs
@@ -10,7 +10,7 @@ using windows = Windows;
 namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
 {
     /// <summary>
-    /// CProvides data for the <see cref="IWebView.WebResourceRequested" /> event. This class cannot be inherited.
+    /// Provides data for the <see cref="IWebView.WebResourceRequested" /> event. This class cannot be inherited.
     /// </summary>
     /// <remarks>Copy from <see cref="windows.Web.UI.WebViewControlWebResourceRequestedEventArgs"/> to avoid requirement to link Windows.winmd</remarks>
     /// <seealso cref="System.EventArgs" />


### PR DESCRIPTION
Issue: #124 

## PR Type
Feature

## What is the current behavior?
WebResourceRequested event is not exposed.

## What is the new behavior?
WebResourceRequested event is exposed by forwarding from the underlying WebViewControl.

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [N/A] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [N/A] Tests for the changes have been added (for bug fixes / features) (if applicable) (N/A)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes
