### PR TITLE
Fix a bug where a Native project does not reference the WinMD

### DIFF
--- a/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/Microsoft.Toolkit.Win32.UI.XamlApplication.Package.csproj
+++ b/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/Microsoft.Toolkit.Win32.UI.XamlApplication.Package.csproj
@@ -73,6 +73,10 @@
       <Pack>true</Pack>
       <PackagePath>build\native</PackagePath>
     </Content>
+    <Content Include="Microsoft.Toolkit.Win32.UI.XamlApplication.props">
+      <Pack>true</Pack>
+      <PackagePath>build\native</PackagePath>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/native/Microsoft.Toolkit.Win32.UI.XamlApplication.targets
+++ b/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/native/Microsoft.Toolkit.Win32.UI.XamlApplication.targets
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Toolkit.Win32.UI.XamlHost.winmd">
+      <Implementation>Microsoft.Toolkit.Win32.UI.XamlHost.dll</Implementation>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Toolkit.Win32.UI.XamlHost.*" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(XamlApp-Platform)\native\Microsoft.Toolkit.Win32.UI.XamlHost.*" />
   </ItemGroup>


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When referencing the XamlApplication project in a native UWP, the App.xaml file cannot be compiled as the reference for the WinMD is missing.

## What is the new behavior?
Add the reference to the WinMD for native projects.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
