### PR TITLE
XamlHost: remove a wildcard that was breaking winmd references

### DIFF
--- a/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/Microsoft.Toolkit.Win32.UI.XamlApplication.Package.csproj
+++ b/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/Microsoft.Toolkit.Win32.UI.XamlApplication.Package.csproj
@@ -7,7 +7,7 @@
     <Description>This library provides XAML islands common helpers for native applications. It is part of the Windows Community Toolkit.</Description>
     <PackageTags>XAML Islands XAMLHost</PackageTags>
     <PackageId>Microsoft.Toolkit.Win32.UI.XamlApplication</PackageId>
-    <Platforms>x64;x86;AnyCPU</Platforms>
+    <Platforms>x64;x86;ARM64;AnyCPU</Platforms>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IsNativeProject>true</IsNativeProject>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>

--- a/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/managed/Microsoft.Toolkit.Win32.UI.XamlApplication.targets
+++ b/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/managed/Microsoft.Toolkit.Win32.UI.XamlApplication.targets
@@ -7,7 +7,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'UAP'">
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\lib\uap10.0\Microsoft.Toolkit.Win32.UI.XamlHost.*" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\lib\uap10.0\Microsoft.Toolkit.Win32.UI.XamlHost.xml" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\runtimes\win10-$(XamlApp-Platform)\native\Microsoft.Toolkit.Win32.UI.XamlHost.*" />
   </ItemGroup>
 </Project>

--- a/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/native/Microsoft.Toolkit.Win32.UI.XamlApplication.targets
+++ b/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/native/Microsoft.Toolkit.Win32.UI.XamlApplication.targets
@@ -6,7 +6,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Toolkit.Win32.UI.XamlHost.*" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Toolkit.Win32.UI.XamlHost.xml" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(XamlApp-Platform)\native\Microsoft.Toolkit.Win32.UI.XamlHost.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Issue: microsoft/terminal#1745

## PR Type
What kind of change does this PR introduce?
Bugfix

## Information
In the toolkit package `targets`, we are adding a `<Reference>` to the `.winmd`. This Reference has an `<Implementation>`.
https://github.com/windows-toolkit/Microsoft.Toolkit.Win32/blob/e308cd3ecd834632253a11158e5609968ab18c1b/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/native/Microsoft.Toolkit.Win32.UI.XamlApplication.targets#L4-L5

Later, we are adding a `<ReferenceCopyLocalPaths>` with a wildcard that _also includes the `.winmd`_! This one is a standard file reference, so it has **no** `<Implementation>`.
https://github.com/windows-toolkit/Microsoft.Toolkit.Win32/blob/e308cd3ecd834632253a11158e5609968ab18c1b/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/native/Microsoft.Toolkit.Win32.UI.XamlApplication.targets#L9

The Appx Packaging task `RemovePayloadDuplicates` is receiving a list where `ReferenceCopyLocalFiles` comes before `References`, and the `.winmd` reference _without_ the Implementation wins. This means that the appx manifest is generated without a reference to the XamlHost DLL.

If we remove the wildcard reference, the warning goes away and the appx manifest is generated with the correct activatable class entry:

```xml
    <Extension Category="windows.activatableClass.inProcessServer">
      <InProcessServer>
        <Path>Microsoft.Toolkit.Win32.UI.XamlHost.dll</Path>
        <ActivatableClass ActivatableClassId="Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication" ThreadingModel="both" />
      </InProcessServer>
    </Extension>
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: Is this necessary for this change? <!-- docs PR link -->
- [x] Contains **NO** breaking changes