### PR TITLE
Wap deployment should include XBF

### DIFF
--- a/Microsoft.WinRT.Win32.targets
+++ b/Microsoft.WinRT.Win32.targets
@@ -25,36 +25,38 @@
       <Output ItemName="_AppxProject" TaskParameter="Include"/>
     </CreateItem>
 
-    <MSBuild Projects="@(_AppxProject)" Properties="Configuration=$(Configuration);Platform=$(Platform)" ContinueOnError="true">
-      <Output TaskParameter="TargetOutputs" ItemName="_AppxBuildOutputPaths"/>
+    <MSBuild Projects="@(_AppxProject)"
+      Properties="Configuration=$(Configuration);Platform=$(Platform)"
+      Targets="Build;GetPackagingOutputs">
+      <Output TaskParameter="TargetOutputs" ItemName="_AppxBuildOutputPaths" />
     </MSBuild>
 
-    <CreateItem Include="%(_AppxBuildOutputPaths.Identity)" AdditionalMetadata="_Project=%(_AppxBuildOutputPaths.MSBuildSourceProjectFile)">
+    <CreateItem Include="%(_AppxBuildOutputPaths.Identity)" Condition="'%(_AppxBuildOutputPaths.TargetPath)'!=''" AdditionalMetadata="Link=%(_AppxBuildOutputPaths.TargetPath)">
       <Output ItemName="_AppxBuildOutputs" TaskParameter="Include"/>
     </CreateItem>
 
-    <CreateItem Include="%(_AppxBuildOutputs.RelativeDir)*.exe;%(_AppxBuildOutputs.RelativeDir)*.dll;%(_AppxBuildOutputs.RelativeDir)*.winmd" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest">
-      <Output ItemName="FilterBin" TaskParameter="Include"/>
-    </CreateItem>
-    <CreateItem Include="@(FilterBin)">
-      <Output ItemName="Content" TaskParameter="Include"/>
-    </CreateItem>
-
-    <CreateItem Include="%(_AppxBuildOutputs.RelativeDir)*.pri" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest">
-      <Output ItemName="FilterPri" TaskParameter="Include"/>
-    </CreateItem>
-    <CreateItem Include="@(FilterPri)">
-      <Output ItemName="Content" TaskParameter="Include"/>
-    </CreateItem>
-
-    <CreateItem Include="%(_AppxBuildOutputs.RelativeDir)**\*.xbf" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest">
+    <CreateItem Include="@(_AppxBuildOutputs)" Condition="'%(_AppxBuildOutputs.Extension)'=='.xbf'" >
       <Output ItemName="FilterXbf" TaskParameter="Include"/>
     </CreateItem>
-    <CreateItem Include="@(FilterXbf)">
+    <CreateItem Include="@(FilterXbf)" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest">
       <Output ItemName="Content" TaskParameter="Include"/>
     </CreateItem>
 
-    <CreateItem Include="%(_AppxBuildOutputs.RelativeDir)AppxManifest.xml">
+    <CreateItem Include="@(_AppxBuildOutputs)" Condition="'%(_AppxBuildOutputs.Extension)'=='.pri'" >
+      <Output ItemName="FilterPri" TaskParameter="Include"/>
+    </CreateItem>
+    <CreateItem Include="@(FilterPri)" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest">
+      <Output ItemName="Content" TaskParameter="Include"/>
+    </CreateItem>
+
+    <CreateItem Include="@(_AppxBuildOutputs)" Condition="'%(_AppxBuildOutputs.Extension)'=='.winmd'" >
+      <Output ItemName="FilterWinMD" TaskParameter="Include"/>
+    </CreateItem>
+    <CreateItem Include="@(FilterWinMD)" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest">
+      <Output ItemName="Content" TaskParameter="Include"/>
+    </CreateItem>
+
+    <CreateItem Include="%(_AppxBuildOutputPaths.RelativeDir)AppxManifest.xml" Condition="Exists('%(_AppxBuildOutputPaths.RelativeDir)AppxManifest.xml')">
       <Output ItemName="AppxManifest" TaskParameter="Include"/>
     </CreateItem>
 

--- a/Microsoft.WinRT.Win32.targets
+++ b/Microsoft.WinRT.Win32.targets
@@ -20,38 +20,43 @@
   </ItemGroup>
 
   <Target Name="CopyAllProjectReferencesOutputs">
-    <MSBuild Projects="@(ProjectReference)" Properties="Configuration=$(Configuration);Platform=$(Platform)" ContinueOnError="true">
-      <Output TaskParameter="TargetOutputs" ItemName="BuildOutputPaths"/>
+
+    <CreateItem Include="@(ProjectReference)" Condition="Exists('%(RelativeDir)\Package.appxmanifest')">
+      <Output ItemName="_AppxProject" TaskParameter="Include"/>
+    </CreateItem>
+
+    <MSBuild Projects="@(_AppxProject)" Properties="Configuration=$(Configuration);Platform=$(Platform)" ContinueOnError="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_AppxBuildOutputPaths"/>
     </MSBuild>
 
-    <CreateItem Include="%(BuildOutputPaths.Identity)" AdditionalMetadata="_Project=%(BuildOutputPaths.MSBuildSourceProjectFile)">
-      <Output ItemName="BuildOutputs" TaskParameter="Include"/>
+    <CreateItem Include="%(_AppxBuildOutputPaths.Identity)" AdditionalMetadata="_Project=%(_AppxBuildOutputPaths.MSBuildSourceProjectFile)">
+      <Output ItemName="_AppxBuildOutputs" TaskParameter="Include"/>
     </CreateItem>
-    <CreateItem Include="%(BuildOutputs.RelativeDir)*.exe;%(BuildOutputs.RelativeDir)*.dll;%(BuildOutputs.RelativeDir)*.winmd" AdditionalMetadata="_Project=%(BuildOutputs._Project);Dir=%(BuildOutputs.RelativeDir)">
+
+    <CreateItem Include="%(_AppxBuildOutputs.RelativeDir)*.exe;%(_AppxBuildOutputs.RelativeDir)*.dll;%(_AppxBuildOutputs.RelativeDir)*.winmd" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest">
       <Output ItemName="FilterBin" TaskParameter="Include"/>
     </CreateItem>
-    <Copy SourceFiles="%(FilterBin.Identity)" ContinueOnError="true" DestinationFolder="$(OutDir)"/>
+    <CreateItem Include="@(FilterBin)">
+      <Output ItemName="Content" TaskParameter="Include"/>
+    </CreateItem>
 
-    <CreateItem Include="%(BuildOutputs.RelativeDir)*.pri;%(BuildOutputs.RelativeDir)*.xbf">
+    <CreateItem Include="%(_AppxBuildOutputs.RelativeDir)*.pri" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest">
       <Output ItemName="FilterPri" TaskParameter="Include"/>
     </CreateItem>
-    <Copy SourceFiles="%(FilterPri.Identity)" ContinueOnError="true" DestinationFolder="$(OutDir)\"/>
-
-    <CreateItem Include="%(BuildOutputs.RelativeDir)AppxManifest*.xml">
-      <Output ItemName="AppxManifest" TaskParameter="Include"/>
+    <CreateItem Include="@(FilterPri)">
+      <Output ItemName="Content" TaskParameter="Include"/>
     </CreateItem>
-    <Copy SourceFiles="%(Filter.Identity)" ContinueOnError="true" DestinationFolder="$(OutDir)"/>
 
-    <GetAssemblyIdentity AssemblyFiles="@(FilterBin)" ContinueOnError="true">
-      <Output
-        TaskParameter="Assemblies"
-        ItemName="AssemblyIdentities"/>
-    </GetAssemblyIdentity>
-
-    <CreateItem Include="%(AssemblyIdentities.Dir)*.xbf" AdditionalMetadata="AsmName=%(AssemblyIdentities.Name)">
+    <CreateItem Include="%(_AppxBuildOutputs.RelativeDir)**\*.xbf" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest">
       <Output ItemName="FilterXbf" TaskParameter="Include"/>
     </CreateItem>
-    <Copy SourceFiles="%(FilterXbf.Identity)" ContinueOnError="true" DestinationFolder="$(OutDir)\%(FilterXbf.AsmName)"/>
+    <CreateItem Include="@(FilterXbf)">
+      <Output ItemName="Content" TaskParameter="Include"/>
+    </CreateItem>
+
+    <CreateItem Include="%(_AppxBuildOutputs.RelativeDir)AppxManifest.xml">
+      <Output ItemName="AppxManifest" TaskParameter="Include"/>
+    </CreateItem>
 
   </Target>
 
@@ -123,11 +128,13 @@
         <activatableClass
             name='{0}'
             threadingModel='both'
-            xmlns='urn:schemas-microsoft-com:winrt.v1'/>", typeName);
+            xmlns='urn:schemas-microsoft-com:winrt.v1'/>
+", typeName);
                     sb.Append(xmlEntry);
                 }
                 var xmlFooter = @"
-    </asmv3:file>";
+    </asmv3:file>
+";
                     sb.Append(xmlFooter);
                 }
             }


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be associated with an issue -->
When deploying a MSIX project that contains custom Xaml controls, the XBF files are not getting deployed.
This is manifest as a Xaml parse exception at runtime.

Please note:
Because of the way WINMD are referenced in the json manifest, flattening of the WAP output is still required.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The MSBuild targets are only deploying for un-packaged projects.

To workaround this issue customers should modify the WAP project to do this:
```
<!-- Stomp the path to application executable. This task will copy the main exe to the appx root folder. -->
  <Target Name="_StompSourceProjectForWapProject" BeforeTargets="_ConvertItems">

    <MSBuild Projects="@(ProjectReference)" Properties="Configuration=$(Configuration);Platform=$(Platform)">
      <Output TaskParameter="TargetOutputs" ItemName="BuildOutputPaths"/>
    </MSBuild>
    <CreateItem Include="%(BuildOutputPaths.RelativeDir)**\*.xbf" AdditionalMetadata="SourceProject=;">
      <Output ItemName="_FilteredNonWapProjProjectOutput" TaskParameter="Include"/>
    </CreateItem>

    <ItemGroup>
      <_TemporaryFilteredWapProjOutput Include="@(_FilteredNonWapProjProjectOutput)" />
      <_FilteredNonWapProjProjectOutput Remove="@(_TemporaryFilteredWapProjOutput)" />
      <_FilteredNonWapProjProjectOutput Include="@(_TemporaryFilteredWapProjOutput)">
        <SourceProject>
        </SourceProject>
      </_FilteredNonWapProjProjectOutput>
    </ItemGroup>
  </Target>

```


## What is the new behavior?
The MSBuild targets have been updated to instead create Content items that are getting copied in both un-packaged and packaged projects.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
