### PR TITLE
Improve Intellisense handling

### DIFF
--- a/Microsoft.WinRT.Win32.targets
+++ b/Microsoft.WinRT.Win32.targets
@@ -8,7 +8,10 @@
     <!-- Up-to-date check fails for Xaml Islands projects: -->
     <!--    https://github.com/dotnet/project-system/issues/5543 -->
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+  </PropertyGroup>
 
+  <PropertyGroup Condition="'$(DesignTimeBuild)' == 'true'">
+    <_DisableAppxCopy>true</_DisableAppxCopy>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -21,7 +24,7 @@
     <IntDir>$(BaseIntermediateOutputPath)\$(Platform)\$(Configuration)\$(TargetFramework)\</IntDir>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.0-rc" />
+    <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.2-rc" />
   </ItemGroup>
 
   <Target Name="_GetUWPAppPayload">
@@ -60,7 +63,8 @@
   <Target Name="CopyAllProjectReferencesOutputs"
       DependsOnTargets="_GetUWPAppPayload;ResolveReferences"
       Inputs="@(_AppxInputs)"
-      Outputs="@(_AppxInputs->'%(FinalTargetPath)')">
+      Outputs="@(_AppxInputs->'%(FinalTargetPath)')"
+      Condition="'$(_DisableAppxCopy)'==''">
 
     <CreateItem Include="%(_AppxBuildOutputPaths.Identity)" Condition="'%(_AppxBuildOutputPaths.TargetPath)'!=''" AdditionalMetadata="Link=%(_AppxBuildOutputPaths.TargetPath)">
       <Output ItemName="_AppxBuildOutputs" TaskParameter="Include"/>
@@ -185,9 +189,11 @@
   </UsingTask>
 
   <Target Name="CreateWinRTRegistration"
+      AfterTargets="ResolveReferences"
       DependsOnTargets="CopyAllProjectReferencesOutputs"
       Inputs="@(AppxManifest);$(ApplicationManifest)"
-      Outputs="$(MergedApplicationManifest)">
+      Outputs="$(MergedApplicationManifest)"
+      Condition="'$(_DisableAppxCopy)'==''">
     <MakeDir Directories="$(IntDir)\Manifests\" />
     <GenerateWinRTManifestFromAppx AppxManifest="@(AppxManifest)" DestinationFolder="$(IntDir)\Manifests\" />
     <CreateItem Include="$(IntDir)Manifests\*.manifest">


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be associated with an issue -->
This change disable Appx project build if a design time build is active

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
MSBuild is active when it should not.

## What is the new behavior?
The Appx msbuild will only be invoked if not design time build is active (the real build)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
