### PR TITLE
Fix MediaPlayer property null for #106 and #68

### DIFF
--- a/Microsoft.Toolkit.Forms.UI.Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/Microsoft.Toolkit.Forms.UI.Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public MediaPlayer MediaPlayer
         {
-            get => UwpControl.MediaPlayer;
+            get => UwpControl?.MediaPlayer;
         }
     }
 }

--- a/Microsoft.Toolkit.Sample.Wpf.App/MainWindow.xaml
+++ b/Microsoft.Toolkit.Sample.Wpf.App/MainWindow.xaml
@@ -28,8 +28,9 @@
             <TabItem>
                 <TabItem.Header>MediaPlayerElement</TabItem.Header>
                 <controls:MediaPlayerElement x:Name="mediaPlayerElement"
+                                     Loaded="mediaPlayerElement_Loaded"
                                      Source="https://mediaplatstorage1.blob.core.windows.net/windows-universal-samples-media/elephantsdream-clip-h264_sd-aac_eng-aac_spa-aac_eng_commentary-srt_eng-srt_por-srt_swe.mkv"
-                                     AutoPlay="True" Margin="5" HorizontalAlignment="Stretch"  VerticalAlignment="Stretch" AreTransportControlsEnabled="True" />
+                                     Margin="5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" AreTransportControlsEnabled="True" />
             </TabItem>
 
             <TabItem>

--- a/Microsoft.Toolkit.Sample.Wpf.App/MainWindow.xaml.cs
+++ b/Microsoft.Toolkit.Sample.Wpf.App/MainWindow.xaml.cs
@@ -153,5 +153,10 @@ namespace Microsoft.Toolkit.Sample.Wpf.App
         {
             await _contentDialog.ShowAsync(windows.UI.Xaml.Controls.ContentDialogPlacement.Popup);
         }
+
+        private void mediaPlayerElement_Loaded(object sender, RoutedEventArgs e)
+        {
+            mediaPlayerElement.MediaPlayer.IsLoopingEnabled = true;
+        }
     }
 }

--- a/Microsoft.Toolkit.Wpf.UI.Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/Microsoft.Toolkit.Wpf.UI.Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
             Bind(nameof(IsFullWindow), IsFullWindowProperty, windows.UI.Xaml.Controls.MediaPlayerElement.IsFullWindowProperty);
             Bind(nameof(AutoPlay), AutoPlayProperty, windows.UI.Xaml.Controls.MediaPlayerElement.AutoPlayProperty);
             Bind(nameof(AreTransportControlsEnabled), AreTransportControlsEnabledProperty, windows.UI.Xaml.Controls.MediaPlayerElement.AreTransportControlsEnabledProperty);
-            Bind(nameof(MediaPlayer), MediaPlayerProperty, windows.UI.Xaml.Controls.MediaPlayerElement.MediaPlayerProperty, null, System.ComponentModel.BindingDirection.OneWay);
 
             // Full-screen not supported yet.
             UwpControl.TransportControls.IsFullWindowButtonVisible = false;
@@ -85,11 +84,6 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
         /// Gets <see cref="windows.UI.Xaml.Controls.MediaPlayerElement.IsFullWindowProperty"/>
         /// </summary>
         public static DependencyProperty IsFullWindowProperty { get; } = DependencyProperty.Register(nameof(IsFullWindow), typeof(bool), typeof(MediaPlayerElement));
-
-        /// <summary>
-        /// Gets <see cref="windows.UI.Xaml.Controls.MediaPlayerElement.MediaPlayerProperty"/>
-        /// </summary>
-        public static DependencyProperty MediaPlayerProperty { get; } = DependencyProperty.Register(nameof(MediaPlayer), typeof(MediaPlayer), typeof(MediaPlayerElement));
 
         /// <summary>
         /// Gets <see cref="windows.UI.Xaml.Controls.MediaPlayerElement.PosterSourceProperty"/>

--- a/Microsoft.Toolkit.Wpf.UI.Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/Microsoft.Toolkit.Wpf.UI.Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
         /// </summary>
         public MediaPlayer MediaPlayer
         {
-            get => (MediaPlayer)GetValue(MediaPlayerProperty);
+            get => UwpControl?.MediaPlayer;
         }
     }
 }


### PR DESCRIPTION
Expose internal property which has correct reference, as was done for WinForms.

Related Issues: #106 and #68

## PR Type
What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
MediaPlayer property always null on MediaPlayerElement for WPF

## What is the new behavior?
MediaPlayer property is now populated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

## Other information

**DO NOT MERGE MASTER into this PR branch YET** The sample app doesn't work on master from commit de0c7e250b86f8e366a1457a4b058d2ee0b5ccb8.  However, I validated the fix at this point in time on the Loaded event in the sample that the `MediaPlayer` property was set and could be manipulated (by setting AutoPlay to false).

Once approved, we can safely merge into master and hopefully fix the side-effect of the other PR preventing the sample app from running.