### PR TITLE
Fall back to WebBrowser controls when running as admin

### DIFF
--- a/Tests/UnitTests.WebView.WinForms/FunctionalTests/WebViewCompatible/WebViewCompatibleTests.cs
+++ b/Tests/UnitTests.WebView.WinForms/FunctionalTests/WebViewCompatible/WebViewCompatibleTests.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Toolkit.Win32.UI.Controls.Test.WebView.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Should;
+using System.Security.Principal;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTests.WebViewCompatible
+{
+    [TestClass]
+    public class WebViewCompatibleTests: ContextSpecification
+    {
+        Forms.UI.Controls.WebViewCompatible WebView;
+
+        protected override void Given()
+        {
+            WebView = new Forms.UI.Controls.WebViewCompatible();
+        }
+
+        [TestMethod]
+        public void WebViewCompatibleShouldBeLegacyIfRunningAsAdministrator()
+        {
+            var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+            if(principal.IsInRole(WindowsBuiltInRole.Administrator))
+            {
+                WebView.IsLegacy.ShouldBeTrue();
+            }
+            else
+            {
+                Assert.Inconclusive("This test needs to be run as administrator");
+            }
+        }
+    }
+}

--- a/WebView.Shared/Interop/OSVersionHelper.cs
+++ b/WebView.Shared/Interop/OSVersionHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Security;
+using System.Security.Principal;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32;
 using Windows.Foundation.Metadata;
 using Windows.Security.EnterpriseData;
@@ -57,6 +58,8 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop
         internal static bool EdgeExists { get; } = File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), ExternDll.EdgeHtml));
 
         internal static bool IsWindows10 { get; } = IsWindowsNt && IsSince(WindowsVersions.Win10);
+
+        internal static bool IsRunningAsAdministrator { get; } = new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
 
         /// <summary>
         /// Gets a value indicating whether the current OS is Windows 10 April 2018 Update (Redstone 4) or greater

--- a/WebView.Shared/Interop/WinRT/WebViewControlHost.cs
+++ b/WebView.Shared/Interop/WinRT/WebViewControlHost.cs
@@ -120,7 +120,8 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
 
         internal static bool IsSupported => OSVersionHelper.IsWindows10April2018OrGreater
                                             && OSVersionHelper.IsWorkstation
-                                            && OSVersionHelper.EdgeExists;
+                                            && OSVersionHelper.EdgeExists
+                                            && !OSVersionHelper.IsRunningAsAdministrator;
 
         internal bool CanGoBack
         {


### PR DESCRIPTION
Fixes #13

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The current behavior is that if you run an application which contains a WebViewCompatible control as administrator the WebViewCompatible controller will not show up (will just be a blank view). See #13 for more details

## What is the new behavior?
With this change, the application will fall back to using WebBrowser (legacy) controls when running the application elevated as administrator so that it the views will still work.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
  - I ran the test suite on x86 and x64 both in .net Framweork and in .net core 3.0, but I don't have any windows ARM devices to run the test suite on. Note that you need to run the test as administrator for it to pass (otherwise it will be inconclusive), and that will make all the other WebView tests fail
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
  - I have not changed any public APIs, so I am not sure it is neccessary to update the documentation
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
   - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates (https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
  - As mentioned, this does not have any public changes so I am not sure if we need to add a sample
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes

## Other information
Just to reiterate for the new tests to pass, we need to run the test suite as administrator, and that will unfortunately make the other tests fail since WebView does not work when running as administrator.