### PR TITLE
Fix a bug where the incorrect CLR assemblies are deployed

### DIFF
--- a/Microsoft.WinRT.Win32.targets
+++ b/Microsoft.WinRT.Win32.targets
@@ -8,6 +8,10 @@
     <!-- Up-to-date check fails for Xaml Islands projects: -->
     <!--    https://github.com/dotnet/project-system/issues/5543 -->
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+
+    <_PlatformShortName_>$(Platform)</_PlatformShortName_>
+    <_PlatformShortName_ Condition="'$(_PlatformShortName_)'=='Win32'">x86</_PlatformShortName_>
+    <_NetCoreUWP_NuGetPackageId>runtime.win10-$(_PlatformShortName_)-aot.Microsoft.NETCore.UniversalWindowsPlatform</_NetCoreUWP_NuGetPackageId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DesignTimeBuild)' == 'true'">
@@ -66,7 +70,9 @@
       Outputs="@(_AppxInputs->'%(FinalTargetPath)')"
       Condition="'$(_DisableAppxCopy)'==''">
 
-    <CreateItem Include="%(_AppxBuildOutputPaths.Identity)" Condition="'%(_AppxBuildOutputPaths.TargetPath)'!=''" AdditionalMetadata="Link=%(_AppxBuildOutputPaths.TargetPath)">
+    <CreateItem Include="@(_AppxBuildOutputPaths)"
+      Condition="'%(_AppxBuildOutputPaths.TargetPath)'!='' and '%(_AppxBuildOutputPaths.NuGetPackageId)'!='$(_NetCoreUWP_NuGetPackageId)'"
+      AdditionalMetadata="Link=%(_AppxBuildOutputPaths.TargetPath)">
       <Output ItemName="_AppxBuildOutputs" TaskParameter="Include"/>
     </CreateItem>
 


### PR DESCRIPTION
Fixes #239 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When creating a MSIX package the incorrect version of the CLR assemblies are deployed making the application crash at startup.

## What is the new behavior?
This changes excludes the UWP NetCore assemblies from deployment in favor of .NET Core 3.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
