### PR TITLE
Account for UWP packages that do not prepend AOT to its name

### DIFF
--- a/Microsoft.WinRT.Win32.targets
+++ b/Microsoft.WinRT.Win32.targets
@@ -11,7 +11,8 @@
 
     <_PlatformShortName_>$(Platform)</_PlatformShortName_>
     <_PlatformShortName_ Condition="'$(_PlatformShortName_)'=='Win32'">x86</_PlatformShortName_>
-    <_NetCoreUWP_NuGetPackageId>runtime.win10-$(_PlatformShortName_)-aot.Microsoft.NETCore.UniversalWindowsPlatform</_NetCoreUWP_NuGetPackageId>
+    <_NetCoreUWP_NuGetPackageId>runtime.win10-$(_PlatformShortName_).Microsoft.NETCore.UniversalWindowsPlatform</_NetCoreUWP_NuGetPackageId>
+    <_NetCoreUWP_AOT_NuGetPackageId>runtime.win10-$(_PlatformShortName_)-aot.Microsoft.NETCore.UniversalWindowsPlatform</_NetCoreUWP_AOT_NuGetPackageId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DesignTimeBuild)' == 'true'">
@@ -71,7 +72,9 @@
       Condition="'$(_DisableAppxCopy)'==''">
 
     <CreateItem Include="@(_AppxBuildOutputPaths)"
-      Condition="'%(_AppxBuildOutputPaths.TargetPath)'!='' and '%(_AppxBuildOutputPaths.NuGetPackageId)'!='$(_NetCoreUWP_NuGetPackageId)'"
+      Condition="'%(_AppxBuildOutputPaths.TargetPath)'!='' and
+        '%(_AppxBuildOutputPaths.NuGetPackageId)'!='$(_NetCoreUWP_AOT_NuGetPackageId)' and
+        '%(_AppxBuildOutputPaths.NuGetPackageId)'!='$(_NetCoreUWP_NuGetPackageId)' "
       AdditionalMetadata="Link=%(_AppxBuildOutputPaths.TargetPath)">
       <Output ItemName="_AppxBuildOutputs" TaskParameter="Include"/>
     </CreateItem>


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
[The previous fix](https://github.com/windows-toolkit/Microsoft.Toolkit.Win32/pull/278) was unfortunately incomplete and did not account for UWP packages that do not append "aot" to the name.

## What is the new behavior?
Add case for packages name without "aot" in the name.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
