### PR TITLE
Save symbol files (pdbs) to the pipeline artifacts

### DIFF
--- a/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/Microsoft.Toolkit.Win32.UI.XamlApplication.Package.csproj
+++ b/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/Microsoft.Toolkit.Win32.UI.XamlApplication.Package.csproj
@@ -32,12 +32,10 @@
       <PackagePath>runtimes\win10-x86\native</PackagePath>
     </Content>
 
-    <!--
-    <Content Include="..\Win32\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pdb">
+    <Content Include="..\Win32\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb">
       <Pack>true</Pack>
-      <PackagePath>runtimes\win10-x86\native</PackagePath>
+      <PackagePath>runtimes\win10-x86\native\Microsoft.Toolkit.Win32.UI.XamlHost.pdb</PackagePath>
     </Content>
-    -->
 
     <Content Include="..\Win32\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pri">
       <Pack>true</Pack>
@@ -49,12 +47,10 @@
       <PackagePath>runtimes\win10-x64\native</PackagePath>
     </Content>
 
-    <!--
-    <Content Include="..\x64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pdb">
+    <Content Include="..\x64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb">
       <Pack>true</Pack>
-      <PackagePath>runtimes\win10-x64\native</PackagePath>
+      <PackagePath>runtimes\win10-x64\native\Microsoft.Toolkit.Win32.UI.XamlHost.pdb</PackagePath>
     </Content>
-    -->
    
     <Content Include="..\x64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pri">
       <Pack>true</Pack>
@@ -66,12 +62,10 @@
       <PackagePath>runtimes\win10-arm\native</PackagePath>
     </Content>
 
-    <!--
-    <Content Include="..\arm\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pdb">
+    <Content Include="..\arm\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb">
       <Pack>true</Pack>
-      <PackagePath>runtimes\win10-arm\native</PackagePath>
+      <PackagePath>runtimes\win10-arm\native\Microsoft.Toolkit.Win32.UI.XamlHost.pdb</PackagePath>
     </Content>
-    -->
 
     <Content Include="..\arm\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pri">
       <Pack>true</Pack>
@@ -83,12 +77,10 @@
       <PackagePath>runtimes\win10-arm64\native</PackagePath>
     </Content>
 
-    <!--
-    <Content Include="..\arm64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pdb">
+    <Content Include="..\arm64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb">
       <Pack>true</Pack>
-      <PackagePath>runtimes\win10-arm64\native</PackagePath>
+      <PackagePath>runtimes\win10-arm64\native\Microsoft.Toolkit.Win32.UI.XamlHost.pdb</PackagePath>
     </Content>
-    -->
 
     <Content Include="..\arm64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pri">
       <Pack>true</Pack>

--- a/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/Microsoft.Toolkit.Win32.UI.XamlApplication.Package.csproj
+++ b/Microsoft.Toolkit.Win32.UI.XamlApplication.Package/Microsoft.Toolkit.Win32.UI.XamlApplication.Package.csproj
@@ -32,10 +32,12 @@
       <PackagePath>runtimes\win10-x86\native</PackagePath>
     </Content>
 
-    <Content Include="..\Win32\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb">
+    <!--
+    <Content Include="..\Win32\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pdb">
       <Pack>true</Pack>
-      <PackagePath>runtimes\win10-x86\native\Microsoft.Toolkit.Win32.UI.XamlHost.pdb</PackagePath>
+      <PackagePath>runtimes\win10-x86\native</PackagePath>
     </Content>
+    -->
 
     <Content Include="..\Win32\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pri">
       <Pack>true</Pack>
@@ -47,10 +49,12 @@
       <PackagePath>runtimes\win10-x64\native</PackagePath>
     </Content>
 
-    <Content Include="..\x64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb">
+    <!--
+    <Content Include="..\x64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pdb">
       <Pack>true</Pack>
-      <PackagePath>runtimes\win10-x64\native\Microsoft.Toolkit.Win32.UI.XamlHost.pdb</PackagePath>
+      <PackagePath>runtimes\win10-x64\native</PackagePath>
     </Content>
+    -->
    
     <Content Include="..\x64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pri">
       <Pack>true</Pack>
@@ -62,10 +66,12 @@
       <PackagePath>runtimes\win10-arm\native</PackagePath>
     </Content>
 
-    <Content Include="..\arm\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb">
+    <!--
+    <Content Include="..\arm\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pdb">
       <Pack>true</Pack>
-      <PackagePath>runtimes\win10-arm\native\Microsoft.Toolkit.Win32.UI.XamlHost.pdb</PackagePath>
+      <PackagePath>runtimes\win10-arm\native</PackagePath>
     </Content>
+    -->
 
     <Content Include="..\arm\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pri">
       <Pack>true</Pack>
@@ -77,10 +83,12 @@
       <PackagePath>runtimes\win10-arm64\native</PackagePath>
     </Content>
 
-    <Content Include="..\arm64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb">
+    <!--
+    <Content Include="..\arm64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pdb">
       <Pack>true</Pack>
-      <PackagePath>runtimes\win10-arm64\native\Microsoft.Toolkit.Win32.UI.XamlHost.pdb</PackagePath>
+      <PackagePath>runtimes\win10-arm64\native</PackagePath>
     </Content>
+    -->
 
     <Content Include="..\arm64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost.pri">
       <Pack>true</Pack>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ pool:
 variables: 
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   BuildConfiguration: Release
+  RepositoryLocalPath : $(Build.Repository.LocalPath)
 
 steps:
 
@@ -36,18 +37,12 @@ steps:
 - script: nbgv cloud
   displayName: Set Version
 
-- powershell: .\build\Install-WindowsSdkISO.ps1 18362
-  displayName: Insider SDK
-
 - task: BatchScript@1
   inputs:
     filename: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\Common7\\Tools\\VsDevCmd.bat"
     arguments: -no_logo
     modifyEnvironment: true
   displayName: Setup Environment Variables
-
-#- powershell: .\build\build.ps1 -target=Package
-#  displayName: Build 
 
 - task: NuGetCommand@2
   displayName: NuGet restore Native projects
@@ -76,6 +71,9 @@ steps:
     msbuildArguments: /target:Build
     restoreNugetPackages: false # Optional
 
+- powershell: "& 'C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\pdbcopy.exe' $env:RepositoryLocalPath\\x64\\Release\\Microsoft.Toolkit.Win32.UI.XamlApplication\\Microsoft.Toolkit.Win32.UI.XamlHost.pdb $env:RepositoryLocalPath\\x64\\Release\\Microsoft.Toolkit.Win32.UI.XamlApplication\\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb -p"
+  displayName: Strip x64
+
 - task: MSBuild@1
   displayName: Build x86 Restore
   inputs:
@@ -93,6 +91,9 @@ steps:
     configuration: Release
     msbuildArguments: /target:Build
     restoreNugetPackages: false # Optional
+
+- powershell: "& 'C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\pdbcopy.exe' $env:RepositoryLocalPath\\Win32\\Release\\Microsoft.Toolkit.Win32.UI.XamlApplication\\Microsoft.Toolkit.Win32.UI.XamlHost.pdb $env:RepositoryLocalPath\\Win32\\Release\\Microsoft.Toolkit.Win32.UI.XamlApplication\\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb -p"
+  displayName: Strip x86
 
 - task: MSBuild@1
   displayName: Build ARM Restore
@@ -112,6 +113,9 @@ steps:
     msbuildArguments: /target:Build
     restoreNugetPackages: false # Optional
 
+- powershell: "& 'C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\pdbcopy.exe' $env:RepositoryLocalPath\\ARM\\Release\\Microsoft.Toolkit.Win32.UI.XamlApplication\\Microsoft.Toolkit.Win32.UI.XamlHost.pdb $env:RepositoryLocalPath\\ARM\\Release\\Microsoft.Toolkit.Win32.UI.XamlApplication\\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb -p"
+  displayName: Strip ARM
+
 - task: MSBuild@1
   displayName: Build ARM64 Restore
   inputs:
@@ -129,6 +133,9 @@ steps:
     configuration: Release
     msbuildArguments: /target:Build
     restoreNugetPackages: false # Optional
+
+- powershell: "& 'C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\pdbcopy.exe' $env:RepositoryLocalPath\\ARM64\\Release\\Microsoft.Toolkit.Win32.UI.XamlApplication\\Microsoft.Toolkit.Win32.UI.XamlHost.pdb $env:RepositoryLocalPath\\ARM64\\Release\\Microsoft.Toolkit.Win32.UI.XamlApplication\\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb -p"
+  displayName: Strip ARM64
 
 - task: MSBuild@1
   displayName: Build Pack

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,3 +162,18 @@ steps:
     pathToPublish: .\bin\nupkg
     artifactType: container
     artifactName: Packages
+
+# Publish stripped pdbs to artifacts
+- task: CopyFiles@2
+  inputs:
+    Contents: |
+      x64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb
+      Win32\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb
+      arm\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb
+      arm64\$(Configuration)\Microsoft.Toolkit.Win32.UI.XamlApplication\Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\symbols\'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: '$(Build.ArtifactStagingDirectory)\symbols' 
+    artifactName: 'symbols' 


### PR DESCRIPTION
Special thanks for @azchohfi who did most of the work here and helped me along!

## What is the current behavior?
Before this change, the pipeline doesn't save out the PDB files.

## What is the new behavior?
After this change, the pipeline will save Microsoft.Toolkit.Win32.UI.XamlHost_stripped.pdb to artifacts.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
